### PR TITLE
jambeth-persistence-jdbc: use osgi-friendly jta dependency

### DIFF
--- a/ambeth-bundles/ambeth-information-bus-with-persistence/kar/pom.xml
+++ b/ambeth-bundles/ambeth-information-bus-with-persistence/kar/pom.xml
@@ -16,6 +16,26 @@
 			<groupId>com.koch.ambeth</groupId>
 			<artifactId>jambeth-information-bus-with-persistence</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>javax.transaction</groupId>
+			<artifactId>javax.transaction-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.interceptor</groupId>
+			<artifactId>javax.interceptor-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.enterprise</groupId>
+			<artifactId>cdi-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.el</groupId>
+			<artifactId>javax.el-api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/ambeth-bundles/ambeth-server-with-persistence/kar/pom.xml
+++ b/ambeth-bundles/ambeth-server-with-persistence/kar/pom.xml
@@ -107,7 +107,7 @@
 			<groupId>com.koch.ambeth</groupId>
 			<artifactId>jambeth-ioc</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>com.koch.ambeth</groupId>
 			<artifactId>jambeth-ioc-osgi</artifactId>
@@ -269,6 +269,21 @@
 		</dependency>
 
 		<dependency>
+			<groupId>javax.interceptor</groupId>
+			<artifactId>javax.interceptor-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.enterprise</groupId>
+			<artifactId>cdi-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>javax.el</groupId>
+			<artifactId>javax.el-api</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>cglib</groupId>
 			<artifactId>cglib</artifactId>
 		</dependency>
@@ -277,11 +292,11 @@
 			<groupId>org.ow2.asm</groupId>
 			<artifactId>asm-all</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>it.sauronsoftware.cron4j</groupId>
 			<artifactId>cron4j</artifactId>
-		</dependency>		
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/ambeth-bundles/ambeth-server-with-persistence/kar/pom.xml
+++ b/ambeth-bundles/ambeth-server-with-persistence/kar/pom.xml
@@ -265,7 +265,7 @@
 
 		<dependency>
 			<groupId>javax.transaction</groupId>
-			<artifactId>jta</artifactId>
+			<artifactId>javax.transaction-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/jambeth/jambeth-cache/src/main/java/com/koch/ambeth/cache/ioc/CacheModule.java
+++ b/jambeth/jambeth-cache/src/main/java/com/koch/ambeth/cache/ioc/CacheModule.java
@@ -71,6 +71,7 @@ import com.koch.ambeth.cache.walker.ICacheWalker;
 import com.koch.ambeth.event.IEventListenerExtendable;
 import com.koch.ambeth.event.IEventTargetExtractorExtendable;
 import com.koch.ambeth.filter.IPagingResponse;
+import com.koch.ambeth.filter.query.service.IGenericQueryService;
 import com.koch.ambeth.ioc.IInitializingModule;
 import com.koch.ambeth.ioc.annotation.Autowired;
 import com.koch.ambeth.ioc.annotation.FrameworkModule;
@@ -275,21 +276,27 @@ public class CacheModule implements IInitializingModule {
 		beanContextFactory.registerBean(CacheContextPostProcessor.class)
 				.propertyValue("CachePostProcessor", cachePostProcessor);
 
-		if (isNetworkClientMode && isCacheServiceBeanActive) {
-			IBeanConfiguration remoteCacheService = beanContextFactory
-					.registerBean(CacheModule.EXTERNAL_CACHE_SERVICE, ClientServiceBean.class)
-					.propertyValue(ClientServiceBean.INTERFACE_PROP_NAME, ICacheService.class)
-					.autowireable(ICacheService.class);
+		if (isNetworkClientMode) {
+			beanContextFactory.registerBean(ClientServiceBean.class)
+					.propertyValue(ClientServiceBean.INTERFACE_PROP_NAME, IGenericQueryService.class)
+					.autowireable(IGenericQueryService.class);
 
-			beanContextFactory.registerAlias(CacheModule.DEFAULT_CACHE_RETRIEVER,
-					CacheModule.EXTERNAL_CACHE_SERVICE);
+			if (isCacheServiceBeanActive) {
+				IBeanConfiguration remoteCacheService = beanContextFactory
+						.registerBean(CacheModule.EXTERNAL_CACHE_SERVICE, ClientServiceBean.class)
+						.propertyValue(ClientServiceBean.INTERFACE_PROP_NAME, ICacheService.class)
+						.autowireable(ICacheService.class);
 
-			// register to all entities in a "most-weak" manner
-			beanContextFactory.link(remoteCacheService).to(ICacheRetrieverExtendable.class)
-					.with(Object.class);
-			// beanContextFactory.RegisterAlias(CacheModule.ROOT_CACHE_RETRIEVER,
-			// CacheModule.EXTERNAL_CACHE_SERVICE);
-			// beanContextFactory.registerBean<CacheServiceDelegate>("cacheService").autowireable<ICacheService>();
+				beanContextFactory.registerAlias(CacheModule.DEFAULT_CACHE_RETRIEVER,
+						CacheModule.EXTERNAL_CACHE_SERVICE);
+
+				// register to all entities in a "most-weak" manner
+				beanContextFactory.link(remoteCacheService).to(ICacheRetrieverExtendable.class)
+						.with(Object.class);
+				// beanContextFactory.RegisterAlias(CacheModule.ROOT_CACHE_RETRIEVER,
+				// CacheModule.EXTERNAL_CACHE_SERVICE);
+				// beanContextFactory.registerBean<CacheServiceDelegate>("cacheService").autowireable<ICacheService>();
+			}
 		}
 
 		beanContextFactory.registerBean(DataObjectMixin.class).autowireable(DataObjectMixin.class);

--- a/jambeth/jambeth-persistence-jdbc/pom.xml
+++ b/jambeth/jambeth-persistence-jdbc/pom.xml
@@ -14,7 +14,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>javax.transaction</groupId>
-			<artifactId>jta</artifactId>
+			<artifactId>javax.transaction-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/jambeth/jambeth-query/src/main/java/com/koch/ambeth/query/ioc/QueryModule.java
+++ b/jambeth/jambeth-query/src/main/java/com/koch/ambeth/query/ioc/QueryModule.java
@@ -6,7 +6,6 @@ import com.koch.ambeth.ioc.config.Property;
 import com.koch.ambeth.ioc.factory.IBeanContextFactory;
 import com.koch.ambeth.query.filter.GenericQueryService;
 import com.koch.ambeth.service.config.ServiceConfigurationConstants;
-import com.koch.ambeth.service.remote.ClientServiceBean;
 
 public class QueryModule implements IInitializingModule {
 
@@ -15,12 +14,7 @@ public class QueryModule implements IInitializingModule {
 
 	@Override
 	public void afterPropertiesSet(IBeanContextFactory beanContextFactory) throws Throwable {
-		if (isNetworkClientMode) {
-			beanContextFactory.registerBean(ClientServiceBean.class)
-					.propertyValue(ClientServiceBean.INTERFACE_PROP_NAME, IGenericQueryService.class)
-					.autowireable(IGenericQueryService.class);
-		}
-		else {
+		if (!isNetworkClientMode) {
 			beanContextFactory.registerBean(GenericQueryService.class)
 					.autowireable(IGenericQueryService.class);
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
 
 			<dependency>
 				<groupId>javax.transaction</groupId>
-				<artifactId>jta</artifactId>
-				<version>1.1</version>
+				<artifactId>javax.transaction-api</artifactId>
+				<version>1.2</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,27 @@
 			</dependency>
 
 			<dependency>
+				<groupId>javax.interceptor</groupId>
+				<artifactId>javax.interceptor-api</artifactId>
+				<version>1.2</version>
+			</dependency>
+
+			<dependency>
 				<groupId>javax.transaction</groupId>
 				<artifactId>javax.transaction-api</artifactId>
 				<version>1.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>javax.enterprise</groupId>
+				<artifactId>cdi-api</artifactId>
+				<version>1.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>javax.el</groupId>
+				<artifactId>javax.el-api</artifactId>
+				<version>2.2.5</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
We can use 
<dependency>
	<groupId>javax.transaction</groupId>
	<artifactId>javax.transaction-api</artifactId>
	<version>1.2</version>
</dependency>
instead of non-osgi library
<dependency>
	<groupId>javax.transaction</groupId>
	<artifactId>jta</artifactId>
	<version>1.1</version>
</dependency>
@Dennis-Koch Can you please try it out? I was able to build ambeth localy.