### PR TITLE
Raise version of base-pom to 1.0.1

### DIFF
--- a/ambeth-integrity/com.koch.classbrowser.compare/pom.xml
+++ b/ambeth-integrity/com.koch.classbrowser.compare/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.koch.ambeth.integrity</groupId>
 		<artifactId>ambeth-integrity-pom</artifactId>
-		<version>1.0.2</version>
+		<version>1.0.3</version>
 	</parent>
 
 	<dependencies>

--- a/ambeth-integrity/com.koch.classbrowser.java/pom.xml
+++ b/ambeth-integrity/com.koch.classbrowser.java/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.koch.ambeth.integrity</groupId>
 		<artifactId>ambeth-integrity-pom</artifactId>
-		<version>1.0.2</version>
+		<version>1.0.3</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/ambeth-integrity/pom.xml
+++ b/ambeth-integrity/pom.xml
@@ -4,13 +4,13 @@
 
 	<groupId>com.koch.ambeth.integrity</groupId>
 	<artifactId>ambeth-integrity-pom</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<packaging>pom</packaging>
 
 	<parent>
 		<groupId>com.koch.ambeth</groupId>
 		<artifactId>base-pom</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<properties>

--- a/chemspider/chemspider-service-test/pom.xml
+++ b/chemspider/chemspider-service-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.koch.ambeth</groupId>
 		<artifactId>chemspider-pom</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<dependencies>

--- a/chemspider/chemspider-service/pom.xml
+++ b/chemspider/chemspider-service/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.koch.ambeth</groupId>
 		<artifactId>chemspider-pom</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<dependencies>

--- a/chemspider/pom.xml
+++ b/chemspider/pom.xml
@@ -4,13 +4,13 @@
 
 	<groupId>com.koch.ambeth</groupId>
 	<artifactId>chemspider-pom</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>pom</packaging>
 	
 	<parent>
 		<groupId>com.koch.ambeth</groupId>
 		<artifactId>base-pom</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 
 	<properties>

--- a/doc/extendables-scanner/pom.xml
+++ b/doc/extendables-scanner/pom.xml
@@ -2,13 +2,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.koch.ambeth</groupId>
 	<artifactId>extendables-scanner</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<packaging>jar</packaging>
 	
 	<parent>
 		<groupId>com.koch.ambeth</groupId>
 		<artifactId>base-pom</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 	
 	<properties>

--- a/doc/reference-manual/pom.xml
+++ b/doc/reference-manual/pom.xml
@@ -9,7 +9,7 @@
 	<properties>
 		<ambeth.version>3.0.2-SNAPSHOT</ambeth.version>
 		<ambeth.integrity.version>1.0.2</ambeth.integrity.version>
-		<ambeth.extendables.scanner.version>1.0.2</ambeth.extendables.scanner.version>
+		<ambeth.extendables.scanner.version>1.0.3</ambeth.extendables.scanner.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<extendables.scanner.dir>${project.build.directory}/extendables-scanner</extendables.scanner.dir>

--- a/jambeth/pom.xml
+++ b/jambeth/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.koch.ambeth</groupId>
 		<artifactId>base-pom</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 	
 	<properties>

--- a/junit-categories/pom.xml
+++ b/junit-categories/pom.xml
@@ -3,14 +3,14 @@
 
 	<groupId>com.koch.ambeth</groupId>
 	<artifactId>junit-categories</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<name>jUnit Categories</name>
 	<description>jUnit Categories for tests</description>
 
 	<parent>
 		<groupId>com.koch.ambeth</groupId>
 		<artifactId>base-pom</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1</version>
 	</parent>
 	
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.koch.ambeth</groupId>
 	<artifactId>base-pom</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -18,7 +18,7 @@
 		<jax.ws.rs.version>2.0.1</jax.ws.rs.version>
 		<tstamp>${maven.build.timestamp}</tstamp>
 		<ambeth.version>3.0.1</ambeth.version>
-		<junit-categories.version>1.0.0</junit-categories.version>
+		<junit-categories.version>1.0.1</junit-categories.version>
 	</properties>
 
 	<scm>


### PR DESCRIPTION
@Dennis-Koch the base-pom was changed in the xpp3 PR but the version was not raised. This PR tries to fix this. Did I get all the versions or is there more?