### PR TITLE
httpclient-enhancement

### DIFF
--- a/ambeth-bundles/ambeth-information-bus/kar/pom.xml
+++ b/ambeth-bundles/ambeth-information-bus/kar/pom.xml
@@ -31,6 +31,27 @@
 			<groupId>org.eclipse.persistence</groupId>
 			<artifactId>javax.persistence</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient-osgi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient-cache</artifactId>
+		</dependency>		
+		<dependency>
+		    <groupId>org.apache.httpcomponents</groupId>
+		    <artifactId>httpcore-osgi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>fluent-hc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpmime</artifactId>
+		</dependency>		
 	</dependencies>
 
 	<build>
@@ -49,15 +70,8 @@
 			<plugin>
 				<groupId>com.bruker.horizon</groupId>
 				<artifactId>kar2tycho-maven-plugin</artifactId>
-				<!-- <executions>
-					<execution>
-						<id>convert</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>kar2tycho</goal>
-						</goals>
-					</execution>
-				</executions> -->
+				<!-- <executions> <execution> <id>convert</id> <phase>verify</phase> 
+					<goals> <goal>kar2tycho</goal> </goals> </execution> </executions> -->
 				<configuration>
 					<sources>
 						<!-- specify your source dependencies here -->

--- a/ambeth-bundles/ambeth-server-with-persistence/kar/pom.xml
+++ b/ambeth-bundles/ambeth-server-with-persistence/kar/pom.xml
@@ -297,6 +297,27 @@
 			<groupId>it.sauronsoftware.cron4j</groupId>
 			<artifactId>cron4j</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient-osgi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient-cache</artifactId>
+		</dependency>		
+		<dependency>
+		    <groupId>org.apache.httpcomponents</groupId>
+		    <artifactId>httpcore-osgi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>fluent-hc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpmime</artifactId>
+		</dependency>		
 	</dependencies>
 
 	<build>

--- a/jambeth/jambeth-service-rest/pom.xml
+++ b/jambeth/jambeth-service-rest/pom.xml
@@ -26,7 +26,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
+			<artifactId>httpclient-osgi</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/jambeth/jambeth-service-rest/pom.xml
+++ b/jambeth/jambeth-service-rest/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>jambeth-service-rest</artifactId>
@@ -22,6 +23,10 @@
 		<dependency>
 			<groupId>javax.ws.rs</groupId>
 			<artifactId>javax.ws.rs-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
 		</dependency>
 	</dependencies>
 </project>

--- a/jambeth/jambeth-service-rest/src/main/java/com/koch/ambeth/service/rest/HttpClientProvider.java
+++ b/jambeth/jambeth-service-rest/src/main/java/com/koch/ambeth/service/rest/HttpClientProvider.java
@@ -1,0 +1,55 @@
+package com.koch.ambeth.service.rest;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import com.koch.ambeth.ioc.IDisposableBean;
+import com.koch.ambeth.util.collections.Tuple3KeyHashMap;
+
+public class HttpClientProvider implements IHttpClientProvider, IDisposableBean {
+
+	protected CloseableHttpClient httpClient;
+
+	protected final Tuple3KeyHashMap<String, Integer, String, HttpHost> hostMap =
+			new Tuple3KeyHashMap<>();
+
+	protected volatile boolean disposed;
+
+	@Override
+	public void destroy() throws Throwable {
+		synchronized (this) {
+			disposed = true;
+			if (httpClient != null) {
+				httpClient.close();
+				httpClient = null;
+			}
+		}
+	}
+
+	@Override
+	public HttpClient getHttpClient() {
+		synchronized (this) {
+			if (httpClient == null) {
+				if (disposed) {
+					throw new IllegalStateException("Bean already disposed");
+				}
+				httpClient = HttpClientBuilder.create().build();
+			}
+			return httpClient;
+		}
+	}
+
+	@Override
+	public HttpHost getHttpHost(String host, int port, String protocol) {
+		synchronized (hostMap) {
+			HttpHost httpHost = hostMap.get(host, port, protocol);
+			if (httpHost == null) {
+				httpHost = new HttpHost(host, port, protocol);
+				hostMap.put(host, port, protocol, httpHost);
+			}
+			return httpHost;
+		}
+	}
+}

--- a/jambeth/jambeth-service-rest/src/main/java/com/koch/ambeth/service/rest/IHttpClientProvider.java
+++ b/jambeth/jambeth-service-rest/src/main/java/com/koch/ambeth/service/rest/IHttpClientProvider.java
@@ -1,0 +1,12 @@
+package com.koch.ambeth.service.rest;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+
+
+public interface IHttpClientProvider {
+
+	HttpClient getHttpClient();
+
+	HttpHost getHttpHost(String host, int port, String protocol);
+}

--- a/jambeth/jambeth-service-rest/src/main/java/com/koch/ambeth/service/rest/ioc/ServiceRESTModule.java
+++ b/jambeth/jambeth-service-rest/src/main/java/com/koch/ambeth/service/rest/ioc/ServiceRESTModule.java
@@ -24,7 +24,9 @@ import com.koch.ambeth.ioc.IInitializingModule;
 import com.koch.ambeth.ioc.factory.IBeanContextFactory;
 import com.koch.ambeth.service.remote.IClientServiceFactory;
 import com.koch.ambeth.service.rest.AuthenticationHolder;
+import com.koch.ambeth.service.rest.HttpClientProvider;
 import com.koch.ambeth.service.rest.IAuthenticationHolder;
+import com.koch.ambeth.service.rest.IHttpClientProvider;
 import com.koch.ambeth.service.rest.RESTClientServiceFactory;
 
 public class ServiceRESTModule implements IInitializingModule {
@@ -35,5 +37,9 @@ public class ServiceRESTModule implements IInitializingModule {
 
 		beanContextFactory.registerBean(AuthenticationHolder.class)
 				.autowireable(IAuthenticationHolder.class);
+
+		beanContextFactory.registerBean(HttpClientProvider.class)
+				.autowireable(IHttpClientProvider.class);
+
 	}
 }

--- a/jambeth/jambeth-service-rest/src/test/java/com/koch/ambeth/service/rest/HttpPerformanceIT.java
+++ b/jambeth/jambeth-service-rest/src/test/java/com/koch/ambeth/service/rest/HttpPerformanceIT.java
@@ -1,0 +1,81 @@
+package com.koch.ambeth.service.rest;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.koch.ambeth.util.collections.Tuple3KeyHashMap;
+import com.koch.ambeth.util.io.FastByteArrayOutputStream;
+
+public class HttpPerformanceIT {
+	@SuppressWarnings("resource")
+	@Test
+	public void performance() throws Throwable {
+
+		int count = 20000;
+		FastByteArrayOutputStream bos = new FastByteArrayOutputStream(4096);
+
+		long start1 = System.currentTimeMillis();
+		for (int a = count; a-- > 0;) {
+			URL url = new URL(
+					"http://localhost:8181/services/services-dynamic/com.koch.ambeth.server.rest.EventServiceREST/getCurrentServerSession");
+			HttpURLConnection con = (HttpURLConnection) url.openConnection();
+			con.setRequestProperty("Accept", Constants.AMBETH_MEDIA_TYPE);
+			con.setRequestMethod("GET");
+			int responseCode = con.getResponseCode();
+			if (responseCode != HttpStatus.SC_OK) {
+				throw new IllegalStateException("ResponseCode: " + responseCode);
+			}
+			try (InputStream is = con.getInputStream()) {
+				bos.reset();
+				int oneByte;
+				while ((oneByte = is.read()) != -1) {
+					bos.write(oneByte);
+				}
+			}
+		}
+		CloseableHttpClient httpClient = HttpClientBuilder.create().evictExpiredConnections().build();
+		try {
+			long start2 = System.currentTimeMillis();
+			Tuple3KeyHashMap<String, Integer, String, HttpHost> hostMap = new Tuple3KeyHashMap<>();
+			for (int a = count; a-- > 0;) {
+				URL url = new URL(
+						"http://localhost:8181/services/services-dynamic/com.koch.ambeth.server.rest.EventServiceREST/getCurrentServerSession");
+				HttpHost httpHost = hostMap.get(url.getHost(), url.getPort(), url.getProtocol());
+				if (httpHost == null) {
+					httpHost = new HttpHost(url.getHost(), url.getPort(), url.getProtocol());
+					hostMap.put(url.getHost(), url.getPort(), url.getProtocol(), httpHost);
+				}
+				HttpUriRequest request = RequestBuilder.create("GET").setUri(url.getPath())
+						.setHeader("Accept", Constants.AMBETH_MEDIA_TYPE).build();
+				try (CloseableHttpResponse response = httpClient.execute(httpHost, request)) {
+					int responseCode = response.getStatusLine().getStatusCode();
+					if (responseCode != HttpStatus.SC_OK) {
+						throw new IllegalStateException("ResponseCode: " + responseCode);
+					}
+					bos.reset();
+					response.getEntity().writeTo(bos);
+				}
+			}
+			long start3 = System.currentTimeMillis();
+
+			System.out
+					.println((start3 - start2) + "ms (httpClient), " + (start2 - start1) + "ms (naive)");
+
+			Assert.assertTrue(start3 - start2 < start2 - start1);
+		}
+		finally {
+			httpClient.close();
+		}
+	}
+}

--- a/jambeth/pom.xml
+++ b/jambeth/pom.xml
@@ -11,12 +11,11 @@
 		<artifactId>base-pom</artifactId>
 		<version>1.0.1</version>
 	</parent>
-	
+
 	<properties>
 		<ambeth.version>${project.version}</ambeth.version>
-		<http.version>4.5.3</http.version>
 	</properties>
-	
+
 	<modules>
 		<module>jambeth-audit</module>
 		<module>jambeth-audit-server</module>
@@ -966,7 +965,7 @@
 				<artifactId>jambeth-security-persistence</artifactId>
 				<version>${project.version}</version>
 				<classifier>sources</classifier>
-				<scope>provided</scope>				
+				<scope>provided</scope>
 			</dependency>
 
 			<dependency>
@@ -1220,7 +1219,7 @@
 				<type>kar</type>
 				<scope>runtime</scope>
 			</dependency>
-			
+
 			<dependency>
 				<groupId>com.koch.ambeth</groupId>
 				<artifactId>jambeth-information-bus-with-persistence</artifactId>
@@ -1270,12 +1269,42 @@
 				<version>${project.version}</version>
 				<scope>test</scope>
 			</dependency>
-			
+
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient-osgi</artifactId>
+				<version>4.5.3</version>
+			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>
 				<artifactId>httpclient</artifactId>
-				<version>${http.version}</version>
-			</dependency>			
+				<version>4.5.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient-cache</artifactId>
+				<version>4.5.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore</artifactId>
+				<version>4.4.6</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpcore-osgi</artifactId>
+				<version>4.4.6</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>fluent-hc</artifactId>
+				<version>4.5.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpmime</artifactId>
+				<version>4.5.3</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/jambeth/pom.xml
+++ b/jambeth/pom.xml
@@ -14,6 +14,7 @@
 	
 	<properties>
 		<ambeth.version>${project.version}</ambeth.version>
+		<http.version>4.5.3</http.version>
 	</properties>
 	
 	<modules>
@@ -1269,6 +1270,12 @@
 				<version>${project.version}</version>
 				<scope>test</scope>
 			</dependency>
+			
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>${http.version}</version>
+			</dependency>			
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
jambeth-service-rest: added HttpClientProvider and used Apache httpclient API for slightly faster HTTP communication (and being in better shape for HTTPS/SSL in the future).

There is a simple JUnit IntegrationTest (HttpPerformanceIT) which expects any locally running REST endpoint to test the API latency between naive Java URL.openConnection() and the Apache HttpClient API. On my machine it prints: "6442ms (httpClient), 6975ms (naive)"  which shows around 8% shorter latency per request.

But there may be an open issue with the httpclient API which does not seem to declare the necessary OSGi headers in the MANIFEST.MF